### PR TITLE
Modified terraform script to deploy the App Engine services, default,…

### DIFF
--- a/backend/dev_deploy.sh
+++ b/backend/dev_deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# First build the bundles in the dist directory
-# The bundles will be used to deploy the app to App Engine
-ng build --configuration=production
+# Deploy the backend api-service
+gcloud app deploy backend.yaml
 
 echo '-----------------------------'
 echo
 
-# Deploy Angular app
-gcloud app deploy frontend.yaml
+# Deploy the ads-conversions-proxy proxy service
+gcloud app deploy proxy/proxy.yaml
+
+echo '-----------------------------'
+echo
+
+# Desploy the dispatch rules for the api-service and ads-conversions-proxy endpoints
+
+gcloud app deploy dispatch.yaml

--- a/frontend/dev_deploy.sh
+++ b/frontend/dev_deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2021 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First build the bundles in the dist directory
+# The bundles will be used to deploy the app to App Engine
+ng build --configuration=production
+
+echo '-----------------------------'
+echo
+
+# Deploy Angular app
+gcloud app deploy frontend.yaml

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,51 @@
-variable "project_folder_id" {
-    type = number
-}
+/***************************************************************************
+*
+*  Copyright 2021 Google Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Note that these code samples being shared are not official Google
+*  products and are not formally supported.
+*
+***************************************************************************/
 
-variable "billing_account" {
+variable "project_id" {
     type = string
+    description = "The Google Cloud project ID"
 }
 
 variable "location" {
     type = string
+    description = "The location where the resources will be deployed"
     default = "us-central"
+}
+
+variable "coop_client_id" {
+    type = string
+    description = "The client id downloaded from the Credentials page"
+}
+
+variable "coop_client_secret" {
+    type = string
+    description = "The client secret downloaded from the Credentials page"
+}
+
+variable "coop_access_token" {
+    type = string
+    description = "The access token generated with the generate_tokens.sh script"
+}
+
+variable "coop_refresh_token" {
+    type = string
+    description = "The refresh token generated with the generate_tokens.sh script"
 }


### PR DESCRIPTION
Modified terraform script to deploy the App Engine services, default, api-service and ads-conversions-proxy. Using bash approach for now. The script also enables the required APIs for the project (CM, Secret Manager) and assigns specific roles to the App Engine default service account.