### PR TITLE
Update confirm-dialog.component.html DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/app/modules/confirm-dialog/confirm-dialog.component.html
+++ b/frontend/src/app/modules/confirm-dialog/confirm-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title>{{data.title}}</h1>
-<div mat-dialog-content [innerHTML]="data.message">
+<div mat-dialog-content [innerText]="data.message">
 </div>
 <div mat-dialog-actions>
     <button mat-button (click)="closeDialog()" cdkFocusInitial>NO</button>


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.